### PR TITLE
chore: 緑色ベースにしてnoindexをつける

### DIFF
--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
   description: "無料で使える中品質なテキスト読み上げソフトウェア。",
   lang: "ja-JP",
   base: "/WIP_docs/",
-  head: [["link", { rel: "icon", href: "/WIP_docs/favicon.ico" }]],
+  head: [
+    ["meta", { name: "theme-color", content: "#a5d4ad" }],
+    ["meta", { name: "robots", content: "noindex" }],
+    ["link", { rel: "icon", href: "/WIP_docs/favicon.ico" }],
+  ],
   cleanUrls: true,
   themeConfig: {
     logo: "/favicon-32x32.png",

--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -7,8 +7,10 @@ export default defineConfig({
   lang: "ja-JP",
   base: "/WIP_docs/",
   head: [
-    ["meta", { name: "theme-color", content: "#a5d4ad" }],
+    // 公開時はnoindexを削除する
     ["meta", { name: "robots", content: "noindex" }],
+
+    ["meta", { name: "theme-color", content: "#a5d4ad" }],
     ["link", { rel: "icon", href: "/WIP_docs/favicon.ico" }],
   ],
   cleanUrls: true,

--- a/src/.vitepress/theme/style.css
+++ b/src/.vitepress/theme/style.css
@@ -1,3 +1,11 @@
 :root {
   --vp-layout-top-height: 3rem;
+
+  /*
+   * メインテーマカラーを緑色にする。
+   */
+  --vp-c-brand-1: var(--vp-c-green-1);
+  --vp-c-brand-2: var(--vp-c-green-2);
+  --vp-c-brand-3: var(--vp-c-green-3);
+  --vp-c-brand-soft: var(--vp-c-green-soft);
 }


### PR DESCRIPTION
## 内容

- 緑色ベースにします。
- metaのtheme-colorを設定します。
  - DiscordのOGPの色がつく
  - 携帯から見た時に上のノッチ部分に色がつく（今はちょっと見栄えが悪いけどバナーが消えたらいい感じになるはず）
- noindexを設定します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

![image](https://github.com/user-attachments/assets/ad91c261-c03f-41d0-8faf-b1730c00993c)
<details>
<summary>iPhoneからのスクショ</summary>

![image](https://github.com/user-attachments/assets/5201289b-cecd-4740-b829-420b084b2f9a)
</details>

## その他

（なし）