### PR TITLE
ci: Pages デプロイ job から不要な contents: read を削除する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     permissions:
-      contents: read
       pages: write
       id-token: write
     steps:


### PR DESCRIPTION
## 内容

GITHUB_TOKEN のデフォルト権限を read-only にする準備として、write が必要な job に permissions を明示します。

- Pages deploy job から不要な `contents: read` を削除します。
- `pages: write` と `id-token: write` は維持します。

## 関連 Issue

ref VOICEVOX/voicevox_project#93
